### PR TITLE
Use ke::AString to store strings from SP safely (Fixes #2)

### DIFF
--- a/curlapi.cpp
+++ b/curlapi.cpp
@@ -22,14 +22,16 @@
 #include "curlapi.h"
 #include "curlthread.h"
 
-char *HTTPClient::BuildURL(const char *endpoint)
+const ke::AString HTTPClient::BuildURL(const ke::AString &endpoint) const
 {
-	char *url = new char[strlen(this->baseURL) + strlen(endpoint) + 2];
-	strcpy(url, this->baseURL);
+	char *url = new char[this->baseURL.length() + endpoint.length() + 2];
+	strcpy(url, this->baseURL.chars());
 	strcat(url, "/");
-	strcat(url, endpoint);
+	strcat(url, endpoint.chars());
 
-	return url;
+	ke::AString ret(url);
+	delete[] url;
+	return ret;
 }
 
 struct curl_slist *HTTPClient::BuildHeaders(struct HTTPRequest request)

--- a/curlapi.h
+++ b/curlapi.h
@@ -29,7 +29,7 @@ class HTTPClient
 public:
 	HTTPClient(const char *baseURL) : baseURL(baseURL) {}
 
-	char *BuildURL(const char *endpoint);
+	const ke::AString BuildURL(const ke::AString &endpoint) const;
 
 	struct curl_slist *BuildHeaders(struct HTTPRequest request);
 
@@ -38,7 +38,7 @@ public:
 	void SetHeader(const char *name, const char *value);
 
 private:
-	const char *baseURL;
+	const ke::AString baseURL;
 	HTTPHeaderMap headers;
 };
 

--- a/curlthread.cpp
+++ b/curlthread.cpp
@@ -62,27 +62,27 @@ void HTTPRequestThread::RunThread(IThreadHandle *pHandle)
 	}
 
 	char error[CURL_ERROR_SIZE] = {'\0'};
-	char *url = this->client->BuildURL(this->request.endpoint);
+	const ke::AString url = this->client->BuildURL(this->request.endpoint);
 
 	struct curl_slist *headers = this->client->BuildHeaders(this->request);
 	struct HTTPResponse response;
 
-	if (strcmp(this->request.method, "POST") == 0)
+	if (this->request.method.compare("POST") == 0)
 	{
 		curl_easy_setopt(curl, CURLOPT_POST, 1L);
 	}
-	else if (strcmp(this->request.method, "PUT") == 0)
+	else if (this->request.method.compare("PUT") == 0)
 	{
 		curl_easy_setopt(curl, CURLOPT_UPLOAD, 1L);
 	}
-	else if (strcmp(this->request.method, "PATCH") == 0)
+	else if (this->request.method.compare("PATCH") == 0)
 	{
-		curl_easy_setopt(curl, CURLOPT_CUSTOMREQUEST, this->request.method);
+		curl_easy_setopt(curl, CURLOPT_CUSTOMREQUEST, this->request.method.chars());
 		curl_easy_setopt(curl, CURLOPT_POST, 1L);
 	}
-	else if (strcmp(this->request.method, "DELETE") == 0)
+	else if (this->request.method.compare("DELETE") == 0)
 	{
-		curl_easy_setopt(curl, CURLOPT_CUSTOMREQUEST, this->request.method);
+		curl_easy_setopt(curl, CURLOPT_CUSTOMREQUEST, this->request.method.chars());
 	}
 
 	curl_easy_setopt(curl, CURLOPT_ACCEPT_ENCODING, "");
@@ -94,7 +94,7 @@ void HTTPRequestThread::RunThread(IThreadHandle *pHandle)
 	curl_easy_setopt(curl, CURLOPT_READDATA, &this->request);
 	curl_easy_setopt(curl, CURLOPT_READFUNCTION, &ReadRequestBody);
 	curl_easy_setopt(curl, CURLOPT_TIMEOUT, 30L);
-	curl_easy_setopt(curl, CURLOPT_URL, url);
+	curl_easy_setopt(curl, CURLOPT_URL, url.chars());
 	curl_easy_setopt(curl, CURLOPT_WRITEDATA, &response);
 	curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, &WriteResponseBody);
 
@@ -104,7 +104,6 @@ void HTTPRequestThread::RunThread(IThreadHandle *pHandle)
 		curl_easy_cleanup(curl);
 		curl_slist_free_all(headers);
 		free(this->request.body);
-		delete[] url;
 
 		smutils->LogError(myself, "HTTP request failed: %s", error);
 		return;
@@ -116,7 +115,6 @@ void HTTPRequestThread::RunThread(IThreadHandle *pHandle)
 	curl_easy_cleanup(curl);
 	curl_slist_free_all(headers);
 	free(this->request.body);
-	delete[] url;
 
 	g_RipExt.AddCallbackToQueue(HTTPRequestCallback(this->forward, response, this->value));
 }

--- a/extension.h
+++ b/extension.h
@@ -43,8 +43,8 @@ struct HTTPRequest {
 		}
 	}
 
-	const char *method;
-	const char *endpoint;
+	const ke::AString method;
+	const ke::AString endpoint;
 	json_t *data;
 
 	char *body;


### PR DESCRIPTION
I _think_ this should be all the cases where SP-owned memory is being persisted internally, all the JSON natives looked fine. This could be fixed with a couple of `strdup`'s instead, but I think using AMTL is saner. `HTTPClient::BuildURL` is slightly unfortunate, appending to a `ke::AString` would be nice, but it is no worse than it was.