### PR TITLE
Optimize performance

### DIFF
--- a/extension.cpp
+++ b/extension.cpp
@@ -170,7 +170,7 @@ static void AsyncPerformRequests(uv_async_t *handle)
 	{
 		context = g_RequestQueue.Pop();
 
-		context.InitCurl();
+		context->InitCurl();
 		curl_multi_add_handle(g_Curl, context->curl);
 	}
 

--- a/extension.cpp
+++ b/extension.cpp
@@ -170,6 +170,7 @@ static void AsyncPerformRequests(uv_async_t *handle)
 	{
 		context = g_RequestQueue.Pop();
 
+		context.InitCurl();
 		curl_multi_add_handle(g_Curl, context->curl);
 	}
 

--- a/httpcontext.cpp
+++ b/httpcontext.cpp
@@ -88,6 +88,7 @@ HTTPContext::~HTTPContext()
 	free(response.body);
 }
 
+// Init curl for http context
 void HTTPContext::InitCurl()
 {
 	curl = curl_easy_init();

--- a/httpcontext.cpp
+++ b/httpcontext.cpp
@@ -77,7 +77,18 @@ static size_t ReceiveResponseHeader(char *buffer, size_t size, size_t nmemb, voi
 HTTPContext::HTTPContext(const ke::AString &method, const ke::AString &url, json_t *data,
 	struct curl_slist *headers, IChangeableForward *forward, cell_t value,
 	long connectTimeout, long followLocation, long timeout)
-	: request(method, url, data), headers(headers), forward(forward), value(value)
+	: request(method, url, data), headers(headers), forward(forward), value(value), connectTimeout(connectTimeout), followLocation(followLocation), timeout(timeout)
+{}
+
+HTTPContext::~HTTPContext()
+{
+	curl_easy_cleanup(curl);
+	curl_slist_free_all(headers);
+	free(request.body);
+	free(response.body);
+}
+
+void HTTPContext::InitCurl()
 {
 	curl = curl_easy_init();
 	if (curl == NULL)
@@ -123,14 +134,6 @@ HTTPContext::HTTPContext(const ke::AString &method, const ke::AString &url, json
 	curl_easy_setopt(curl, CURLOPT_URL, request.url.chars());
 	curl_easy_setopt(curl, CURLOPT_WRITEDATA, &response);
 	curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, &WriteResponseBody);
-}
-
-HTTPContext::~HTTPContext()
-{
-	curl_easy_cleanup(curl);
-	curl_slist_free_all(headers);
-	free(request.body);
-	free(response.body);
 }
 
 void HTTPContext::OnCompleted()

--- a/httpcontext.h
+++ b/httpcontext.h
@@ -32,6 +32,7 @@ public:
 		long connectTimeout, long followLocation, long timeout);
 	~HTTPContext();
 
+	void InitCurl();
 	void OnCompleted();
 
 	CURL *curl;
@@ -43,6 +44,9 @@ private:
 	IChangeableForward *forward;
 	cell_t value;
 	char error[CURL_ERROR_SIZE] = {'\0'};
+	long connectTimeout;
+	long followLocation;
+	long timeout;
 };
 
 #endif // SM_RIPEXT_HTTPCONTEXT_H_


### PR DESCRIPTION
## Change

1. Move init curl from `HTTPContext constructor` to `HTTPContext::InitCurl` and be called in `AsyncPerformRequests()`

2. Add limiter for `RequestQueue` and `CompletedRequestQueue` to reduce the impact on frame rendering time 
**Prevent mass request (1000+ request) processing in a tick**
Macro: `MAX_PROCESS` in `extension.cpp`

> When using GameFrameHook, any operations in hook will affect frame rendering time 🤔 