### PR TITLE
Update code design for JSON flags

### DIFF
--- a/pawn/scripting/include/ripext/json.inc
+++ b/pawn/scripting/include/ripext/json.inc
@@ -5,7 +5,7 @@ enum
 	JSON_DISABLE_EOF_CHECK  = 0x2,		/**< Allow extra data after a valid JSON array or object */
 	JSON_DECODE_ANY         = 0x4,		/**< Decode any value */
 	JSON_DECODE_INT_AS_REAL = 0x8,		/**< Interpret all numbers as floats */
-	JSON_ALLOW_NUL          = 0x10		/**< Allow \u0000 escape inside string values */
+	JSON_ALLOW_NULL         = 0x10		/**< Allow \u0000 escape inside string values */
 };
 
 // Encoding flags

--- a/pawn/scripting/include/ripext/json.inc
+++ b/pawn/scripting/include/ripext/json.inc
@@ -1,22 +1,24 @@
 // Decoding flags
 enum
 {
-	JSON_REJECT_DUPLICATES  = 0x1,		/**< Error if any JSON object contains duplicate keys */
-	JSON_DISABLE_EOF_CHECK  = 0x2,		/**< Allow extra data after a valid JSON array or object */
-	JSON_DECODE_ANY         = 0x4,		/**< Decode any value */
-	JSON_DECODE_INT_AS_REAL = 0x8,		/**< Interpret all numbers as floats */
-	JSON_ALLOW_NULL         = 0x10		/**< Allow \u0000 escape inside string values */
+	JSON_REJECT_DUPLICATES  = (1 << 0),		/**< Error if any JSON object contains duplicate keys */
+	JSON_DISABLE_EOF_CHECK  = (1 << 1),		/**< Allow extra data after a valid JSON array or object */
+	JSON_DECODE_ANY         = (1 << 2),		/**< Decode any value */
+	JSON_DECODE_INT_AS_REAL = (1 << 3),		/**< Interpret all numbers as floats */
+	JSON_ALLOW_NULL         = (1 << 4)		/**< Allow \u0000 escape inside string values */
 };
 
 // Encoding flags
 enum
 {
-	JSON_COMPACT      = 0x20,		/**< Compact representation */
-	JSON_ENSURE_ASCII = 0x40,		/**< Escape all Unicode characters outside the ASCII range */
-	JSON_SORT_KEYS    = 0x80,		/**< Sort object keys */
-	JSON_ENCODE_ANY   = 0x200,		/**< Encode any value */
-	JSON_ESCAPE_SLASH = 0x400,		/**< Escape / with \/ */
-	JSON_EMBED        = 0x10000		/**< Omit opening and closing braces of the top-level object */
+	JSON_COMPACT      = (1 << 5),		/**< Compact representation */
+	JSON_ENSURE_ASCII = (1 << 6),		/**< Escape all Unicode characters outside the ASCII range */
+	JSON_SORT_KEYS    = (1 << 7),		/**< Sort object keys */
+
+	JSON_ENCODE_ANY   = (1 << 9),		/**< Encode any value */
+	JSON_ESCAPE_SLASH = (1 << 10),		/**< Escape / with \/ */
+
+	JSON_EMBED        = (1 << 16)		/**< Omit opening and closing braces of the top-level object */
 };
 
 // Maximum indentation


### PR DESCRIPTION
Replace hexadecimal flags to bit offets.
Fixed a typo instead of `JSON_ALLOW_NUL` on `JSON_ALLOW_NULL`.