### PR TITLE
Allow user defined 'Accept' and 'Content-Type' headers

### DIFF
--- a/httprequest.cpp
+++ b/httprequest.cpp
@@ -23,11 +23,16 @@
 #include "httprequestcontext.h"
 #include "httpfilecontext.h"
 
+HTTPRequest::HTTPRequest(const std::string &url)
+: url(url)
+{
+	SetHeader("Accept", "application/json");
+	SetHeader("Content-Type", "applicaton/json");
+}
+
 void HTTPRequest::Perform(const char *method, json_t *data, IChangeableForward *forward, cell_t value)
 {
 	struct curl_slist *headers = NULL;
-	SetHeader("Accept", "application/json");
-	SetHeader("Content-Type", "applicaton/json");
 	headers = this->BuildHeaders(headers);
 
 	HTTPRequestContext *context = new HTTPRequestContext(method, this->BuildURL(), data, headers, forward, value,

--- a/httprequest.cpp
+++ b/httprequest.cpp
@@ -23,11 +23,16 @@
 #include "httprequestcontext.h"
 #include "httpfilecontext.h"
 
+HTTPRequest::HTTPRequest(const std::string &url)
+: url(url)
+{
+	SetHeader("Accept", "application/json");
+	SetHeader("Content-Type", "applicaton/json");
+}
+
 void HTTPRequest::Perform(const char *method, json_t *data, IChangeableForward *forward, cell_t value)
 {
 	struct curl_slist *headers = NULL;
-	headers = curl_slist_append(headers, "Accept: application/json");
-	headers = curl_slist_append(headers, "Content-Type: application/json");
 	headers = this->BuildHeaders(headers);
 
 	HTTPRequestContext *context = new HTTPRequestContext(method, this->BuildURL(), data, headers, forward, value,

--- a/httprequest.cpp
+++ b/httprequest.cpp
@@ -23,16 +23,11 @@
 #include "httprequestcontext.h"
 #include "httpfilecontext.h"
 
-HTTPRequest::HTTPRequest(const std::string &url)
-: url(url)
-{
-	SetHeader("Accept", "application/json");
-	SetHeader("Content-Type", "applicaton/json");
-}
-
 void HTTPRequest::Perform(const char *method, json_t *data, IChangeableForward *forward, cell_t value)
 {
 	struct curl_slist *headers = NULL;
+	SetHeader("Accept", "application/json");
+	SetHeader("Content-Type", "applicaton/json");
 	headers = this->BuildHeaders(headers);
 
 	HTTPRequestContext *context = new HTTPRequestContext(method, this->BuildURL(), data, headers, forward, value,
@@ -45,8 +40,8 @@ void HTTPRequest::Perform(const char *method, json_t *data, IChangeableForward *
 void HTTPRequest::DownloadFile(const char *path, IChangeableForward *forward, cell_t value)
 {
 	struct curl_slist *headers = NULL;
-	headers = curl_slist_append(headers, "Accept: */*");
-	headers = curl_slist_append(headers, "Content-Type: application/octet-stream");
+	SetHeader("Accept", "*/*");
+	SetHeader("Content-Type", "application/octet-stream");
 	headers = this->BuildHeaders(headers);
 
 	HTTPFileContext *context = new HTTPFileContext(false, this->BuildURL(), path, headers, forward, value,
@@ -59,8 +54,8 @@ void HTTPRequest::DownloadFile(const char *path, IChangeableForward *forward, ce
 void HTTPRequest::UploadFile(const char *path, IChangeableForward *forward, cell_t value)
 {
 	struct curl_slist *headers = NULL;
-	headers = curl_slist_append(headers, "Accept: */*");
-	headers = curl_slist_append(headers, "Content-Type: application/octet-stream");
+	SetHeader("Accept", "*/*");
+	SetHeader("Content-Type", "application/octet-stream");
 	headers = this->BuildHeaders(headers);
 
 	HTTPFileContext *context = new HTTPFileContext(true, this->BuildURL(), path, headers, forward, value,

--- a/httprequest.h
+++ b/httprequest.h
@@ -27,7 +27,7 @@
 class HTTPRequest
 {
 public:
-	HTTPRequest(const std::string &url);
+	HTTPRequest(const std::string &url) : url(url) {}
 
 	void Perform(const char *method, json_t *data, IChangeableForward *forward, cell_t value);
 	void DownloadFile(const char *path, IChangeableForward *forward, cell_t value);

--- a/httprequest.h
+++ b/httprequest.h
@@ -27,7 +27,7 @@
 class HTTPRequest
 {
 public:
-	HTTPRequest(const std::string &url) : url(url) {}
+	HTTPRequest(const std::string &url);
 
 	void Perform(const char *method, json_t *data, IChangeableForward *forward, cell_t value);
 	void DownloadFile(const char *path, IChangeableForward *forward, cell_t value);


### PR DESCRIPTION
This allows users to override the 'Accept' and 'Content-Type' headers that were previously hard coded, as if you added them yourself they would just be appended. Some applications such as [PayPal's access token](https://developer.paypal.com/docs/api/get-an-access-token-curl/) request were impossible to use as the hard coded header took prescience over the one added by the plugin even though they were both sent. The default values are still set, but now they are set in the same way as the other headers so they can be overridden.