### PR TITLE
Fix BuildHeaders for HTTPRequest

### DIFF
--- a/httprequest.cpp
+++ b/httprequest.cpp
@@ -124,10 +124,14 @@ struct curl_slist *HTTPRequest::BuildHeaders(const char *acceptTypes, const char
 	struct curl_slist *headers = NULL;
 	char header[8192];
 
-	snprintf(header, sizeof(header), "Accept: %s", acceptTypes);
+	auto result = this->headers.find("Accept");
+
+	snprintf(header, sizeof(header), "Accept: %s", result.found() ? (*result).value.c_str() : acceptTypes);
 	headers = curl_slist_append(headers, header);
 
-	snprintf(header, sizeof(header), "Content-Type: %s", contentType);
+	result = this->headers.find("Content-Type");
+
+	snprintf(header, sizeof(header), "Content-Type: %s", result.found() ? (*result).value.c_str() : contentType);
 	headers = curl_slist_append(headers, header);
 
 	for (HTTPHeaderMap::iterator iter = this->headers.iter(); !iter.empty(); iter.next())

--- a/httprequest.cpp
+++ b/httprequest.cpp
@@ -125,14 +125,26 @@ struct curl_slist *HTTPRequest::BuildHeaders(const char *acceptTypes, const char
 	char header[8192];
 
 	auto result = this->headers.find("Accept");
+	bool result_is_found = result.found();
 
-	snprintf(header, sizeof(header), "Accept: %s", result.found() ? (*result).value.c_str() : acceptTypes);
+	snprintf(header, sizeof(header), "Accept: %s", result_is_found ? (*result).value.c_str() : acceptTypes);
 	headers = curl_slist_append(headers, header);
+
+	if(result_is_found)
+	{
+		this->headers.remove(result);
+	}
 
 	result = this->headers.find("Content-Type");
+	result_is_found = result.found();
 
-	snprintf(header, sizeof(header), "Content-Type: %s", result.found() ? (*result).value.c_str() : contentType);
+	snprintf(header, sizeof(header), "Content-Type: %s", result_is_found ? (*result).value.c_str() : contentType);
 	headers = curl_slist_append(headers, header);
+
+	if(result_is_found)
+	{
+		this->headers.remove(result);
+	}
 
 	for (HTTPHeaderMap::iterator iter = this->headers.iter(); !iter.empty(); iter.next())
 	{

--- a/httprequest.h
+++ b/httprequest.h
@@ -39,7 +39,7 @@ public:
 
 	void AppendFormParam(const char *name, const char *value);
 
-	struct curl_slist *BuildHeaders();
+	struct curl_slist *BuildHeaders(const char *acceptTypes, const char *contentType);
 	void SetHeader(const char *name, const char *value);
 
 	bool UseBasicAuth() const;


### PR DESCRIPTION
When adding an additional header for HTTPRequest POST requests, RiP did not send JSON data to the WEB server. This Pull Request fixes this issue.
This problem arose as a result of unordered elements in `HTTPHeaderMap (aka StringHashMap<std::string>)` `headers` field in `HTTPRequest`, so 'Accept' and 'Content-Type' headers not at the beginning of the HTTP request. Because of this, there were losses of the sent data.

Also https://forums.alliedmods.net/showpost.php?p=2749171&postcount=103 .