### PR TITLE
Add request body size to cURL options

### DIFF
--- a/httpfilecontext.cpp
+++ b/httpfilecontext.cpp
@@ -91,10 +91,6 @@ bool HTTPFileContext::InitCurl()
 	curl_easy_setopt(curl, CURLOPT_URL, url.c_str());
 	curl_easy_setopt(curl, CURLOPT_USERAGENT, SM_RIPEXT_USER_AGENT);
 
-#ifdef DEBUG
-	curl_easy_setopt(curl, CURLOPT_VERBOSE, 1L);
-#endif
-
 	if (maxRecvSpeed > 0)
 	{
 		curl_easy_setopt(curl, CURLOPT_MAX_RECV_SPEED_LARGE, maxRecvSpeed);
@@ -108,6 +104,10 @@ bool HTTPFileContext::InitCurl()
 		curl_easy_setopt(curl, CURLOPT_USERNAME, username.c_str());
 		curl_easy_setopt(curl, CURLOPT_PASSWORD, password.c_str());
 	}
+
+#ifdef DEBUG
+	curl_easy_setopt(curl, CURLOPT_VERBOSE, 1L);
+#endif
 
 #ifdef WIN32
 	curl_easy_setopt(curl, CURLOPT_HTTP_VERSION, CURL_HTTP_VERSION_1_1);
@@ -137,7 +137,6 @@ void HTTPFileContext::OnCompleted()
 
 off_t FileSize(FILE *fd)
 {
-
 #ifdef WIN32
 	struct _stat file_info;
 	int stat_res = _fstat(fileno(fd), &file_info);

--- a/httpfilecontext.cpp
+++ b/httpfilecontext.cpp
@@ -109,7 +109,9 @@ bool HTTPFileContext::InitCurl()
 		curl_easy_setopt(curl, CURLOPT_PASSWORD, password.c_str());
 	}
 
-	curl_easy_setopt(curl, CURLOPT_HTTP_VERSION, CURL_HTTP_VERSION_1_0);
+#ifdef WIN32
+	curl_easy_setopt(curl, CURLOPT_HTTP_VERSION, CURL_HTTP_VERSION_1_1);
+#endif
 
 	return true;
 }

--- a/httpfilecontext.cpp
+++ b/httpfilecontext.cpp
@@ -69,7 +69,7 @@ bool HTTPFileContext::InitCurl()
 		curl_easy_setopt(curl, CURLOPT_READFUNCTION, fread);
 		curl_easy_setopt(curl, CURLOPT_UPLOAD, 1L);
 		curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, &IgnoreResponseBody);
-        curl_easy_setopt(curl, CURLOPT_INFILESIZE_LARGE, (curl_off_t) FileSize(file));
+		curl_easy_setopt(curl, CURLOPT_INFILESIZE_LARGE, (curl_off_t) FileSize(file));
 	}
 	else
 	{
@@ -92,7 +92,7 @@ bool HTTPFileContext::InitCurl()
 	curl_easy_setopt(curl, CURLOPT_USERAGENT, SM_RIPEXT_USER_AGENT);
 
 #ifdef DEBUG
-    curl_easy_setopt(curl, CURLOPT_VERBOSE, 1L);
+	curl_easy_setopt(curl, CURLOPT_VERBOSE, 1L);
 #endif
 
 	if (maxRecvSpeed > 0)
@@ -139,17 +139,17 @@ off_t FileSize(FILE *fd)
 {
 
 #ifdef WIN32
-    struct _stat file_info;
-    int stat_res = _fstat(fileno(fd), &file_info);
+	struct _stat file_info;
+	int stat_res = _fstat(fileno(fd), &file_info);
 #else
-    struct stat file_info;
-    int stat_res = fstat(fileno(fd), &file_info);
+	struct stat file_info;
+	int stat_res = fstat(fileno(fd), &file_info);
 #endif // WIN32
 
-    if (stat_res != 0)
-    {
-        return -1;
-    }
+	if (stat_res != 0)
+	{
+		return -1;
+	}
 
-    return file_info.st_size;
+	return file_info.st_size;
 }

--- a/httpfilecontext.cpp
+++ b/httpfilecontext.cpp
@@ -20,6 +20,7 @@
  */
 
 #include "httpfilecontext.h"
+#include <sys/stat.h>
 
 static size_t IgnoreResponseBody(void *body, size_t size, size_t nmemb, void *userdata)
 {
@@ -68,6 +69,7 @@ bool HTTPFileContext::InitCurl()
 		curl_easy_setopt(curl, CURLOPT_READFUNCTION, fread);
 		curl_easy_setopt(curl, CURLOPT_UPLOAD, 1L);
 		curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, &IgnoreResponseBody);
+        curl_easy_setopt(curl, CURLOPT_INFILESIZE_LARGE, (curl_off_t) FileSize(file));
 	}
 	else
 	{
@@ -89,6 +91,10 @@ bool HTTPFileContext::InitCurl()
 	curl_easy_setopt(curl, CURLOPT_URL, url.c_str());
 	curl_easy_setopt(curl, CURLOPT_USERAGENT, SM_RIPEXT_USER_AGENT);
 
+#ifdef DEBUG
+    curl_easy_setopt(curl, CURLOPT_VERBOSE, 1L);
+#endif
+
 	if (maxRecvSpeed > 0)
 	{
 		curl_easy_setopt(curl, CURLOPT_MAX_RECV_SPEED_LARGE, maxRecvSpeed);
@@ -103,9 +109,7 @@ bool HTTPFileContext::InitCurl()
 		curl_easy_setopt(curl, CURLOPT_PASSWORD, password.c_str());
 	}
 
-#if defined(WIN32)
-	curl_easy_setopt(curl, CURLOPT_HTTP_VERSION, CURL_HTTP_VERSION_1_1);
-#endif
+	curl_easy_setopt(curl, CURLOPT_HTTP_VERSION, CURL_HTTP_VERSION_1_0);
 
 	return true;
 }
@@ -127,4 +131,23 @@ void HTTPFileContext::OnCompleted()
 	forward->PushCell(value);
 	forward->PushString(error);
 	forward->Execute(NULL);
+}
+
+off_t FileSize(FILE *fd)
+{
+
+#ifdef WIN32
+    struct _stat file_info;
+    int stat_res = _fstat(fileno(fd), &file_info);
+#else
+    struct stat file_info;
+    int stat_res = fstat(fileno(fd), &file_info);
+#endif // WIN32
+
+    if (stat_res != 0)
+    {
+        return -1;
+    }
+
+    return file_info.st_size;
 }

--- a/httpfilecontext.h
+++ b/httpfilecontext.h
@@ -58,4 +58,6 @@ private:
 	const std::string password;
 };
 
+off_t FileSize(FILE *fd);
+
 #endif // SM_RIPEXT_HTTPFILECONTEXT_H_

--- a/httpformcontext.cpp
+++ b/httpformcontext.cpp
@@ -114,10 +114,6 @@ bool HTTPFormContext::InitCurl()
 	curl_easy_setopt(curl, CURLOPT_WRITEDATA, &response);
 	curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, &WriteResponseBody);
 
-#ifdef DEBUG
-	curl_easy_setopt(curl, CURLOPT_VERBOSE, 1L);
-#endif
-
 	if (maxRecvSpeed > 0)
 	{
 		curl_easy_setopt(curl, CURLOPT_MAX_RECV_SPEED_LARGE, maxRecvSpeed);
@@ -131,6 +127,10 @@ bool HTTPFormContext::InitCurl()
 		curl_easy_setopt(curl, CURLOPT_USERNAME, username.c_str());
 		curl_easy_setopt(curl, CURLOPT_PASSWORD, password.c_str());
 	}
+
+#ifdef DEBUG
+	curl_easy_setopt(curl, CURLOPT_VERBOSE, 1L);
+#endif
 
 	return true;
 }

--- a/httpformcontext.cpp
+++ b/httpformcontext.cpp
@@ -114,6 +114,10 @@ bool HTTPFormContext::InitCurl()
 	curl_easy_setopt(curl, CURLOPT_WRITEDATA, &response);
 	curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, &WriteResponseBody);
 
+#ifdef DEBUG
+    curl_easy_setopt(curl, CURLOPT_VERBOSE, 1L);
+#endif
+
 	if (maxRecvSpeed > 0)
 	{
 		curl_easy_setopt(curl, CURLOPT_MAX_RECV_SPEED_LARGE, maxRecvSpeed);

--- a/httpformcontext.cpp
+++ b/httpformcontext.cpp
@@ -115,7 +115,7 @@ bool HTTPFormContext::InitCurl()
 	curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, &WriteResponseBody);
 
 #ifdef DEBUG
-    curl_easy_setopt(curl, CURLOPT_VERBOSE, 1L);
+	curl_easy_setopt(curl, CURLOPT_VERBOSE, 1L);
 #endif
 
 	if (maxRecvSpeed > 0)

--- a/httprequestcontext.cpp
+++ b/httprequestcontext.cpp
@@ -150,11 +150,11 @@ bool HTTPRequestContext::InitCurl()
 	curl_easy_setopt(curl, CURLOPT_USERAGENT, SM_RIPEXT_USER_AGENT);
 	curl_easy_setopt(curl, CURLOPT_WRITEDATA, &response);
 	curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, &WriteResponseBody);
-    curl_easy_setopt(curl, CURLOPT_INFILESIZE_LARGE, (curl_off_t) ((size == 0) ? -1 : size));
-    curl_easy_setopt(curl, CURLOPT_POSTFIELDSIZE_LARGE, (curl_off_t) ((size == 0) ? -1 : size));
+	curl_easy_setopt(curl, CURLOPT_INFILESIZE_LARGE, (curl_off_t) ((size == 0) ? -1 : size));
+	curl_easy_setopt(curl, CURLOPT_POSTFIELDSIZE_LARGE, (curl_off_t) ((size == 0) ? -1 : size));
 
 #ifdef DEBUG
-    curl_easy_setopt(curl, CURLOPT_VERBOSE, 1L);
+	curl_easy_setopt(curl, CURLOPT_VERBOSE, 1L);
 #endif
 
 	if (maxRecvSpeed > 0)

--- a/httprequestcontext.cpp
+++ b/httprequestcontext.cpp
@@ -150,6 +150,12 @@ bool HTTPRequestContext::InitCurl()
 	curl_easy_setopt(curl, CURLOPT_USERAGENT, SM_RIPEXT_USER_AGENT);
 	curl_easy_setopt(curl, CURLOPT_WRITEDATA, &response);
 	curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, &WriteResponseBody);
+    curl_easy_setopt(curl, CURLOPT_INFILESIZE_LARGE, (curl_off_t) ((size == 0) ? -1 : size));
+    curl_easy_setopt(curl, CURLOPT_POSTFIELDSIZE_LARGE, (curl_off_t) ((size == 0) ? -1 : size));
+
+#ifdef DEBUG
+    curl_easy_setopt(curl, CURLOPT_VERBOSE, 1L);
+#endif
 
 	if (maxRecvSpeed > 0)
 	{

--- a/httprequestcontext.cpp
+++ b/httprequestcontext.cpp
@@ -116,15 +116,18 @@ bool HTTPRequestContext::InitCurl()
 	if (method.compare("POST") == 0)
 	{
 		curl_easy_setopt(curl, CURLOPT_POST, 1L);
+		curl_easy_setopt(curl, CURLOPT_POSTFIELDSIZE_LARGE, (curl_off_t) size);
 	}
 	else if (method.compare("PUT") == 0)
 	{
 		curl_easy_setopt(curl, CURLOPT_UPLOAD, 1L);
+		curl_easy_setopt(curl, CURLOPT_INFILESIZE_LARGE, (curl_off_t) size);
 	}
 	else if (method.compare("PATCH") == 0)
 	{
 		curl_easy_setopt(curl, CURLOPT_CUSTOMREQUEST, method.c_str());
 		curl_easy_setopt(curl, CURLOPT_POST, 1L);
+		curl_easy_setopt(curl, CURLOPT_POSTFIELDSIZE_LARGE, (curl_off_t) size);
 	}
 	else if (method.compare("DELETE") == 0)
 	{
@@ -150,12 +153,6 @@ bool HTTPRequestContext::InitCurl()
 	curl_easy_setopt(curl, CURLOPT_USERAGENT, SM_RIPEXT_USER_AGENT);
 	curl_easy_setopt(curl, CURLOPT_WRITEDATA, &response);
 	curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, &WriteResponseBody);
-	curl_easy_setopt(curl, CURLOPT_INFILESIZE_LARGE, (curl_off_t) ((size == 0) ? -1 : size));
-	curl_easy_setopt(curl, CURLOPT_POSTFIELDSIZE_LARGE, (curl_off_t) ((size == 0) ? -1 : size));
-
-#ifdef DEBUG
-	curl_easy_setopt(curl, CURLOPT_VERBOSE, 1L);
-#endif
 
 	if (maxRecvSpeed > 0)
 	{
@@ -170,6 +167,10 @@ bool HTTPRequestContext::InitCurl()
 		curl_easy_setopt(curl, CURLOPT_USERNAME, username.c_str());
 		curl_easy_setopt(curl, CURLOPT_PASSWORD, password.c_str());
 	}
+
+#ifdef DEBUG
+	curl_easy_setopt(curl, CURLOPT_VERBOSE, 1L);
+#endif
 
 	return true;
 }


### PR DESCRIPTION
This fixes the issue mentioned [here](https://github.com/ErikMinekus/sm-ripext/pull/51#issuecomment-903483204) with sending any request body from servers running on Windows.
