### PR TITLE
JSON Natives: `*.GetFloat()` gets number, instead of real

### DIFF
--- a/json_natives.cpp
+++ b/json_natives.cpp
@@ -136,7 +136,7 @@ static cell_t GetObjectFloatValue(IPluginContext *pContext, const cell_t *params
 		return pContext->ThrowNativeError("Could not retrieve value for key '%s'", key);
 	}
 
-	return sp_ftoc(static_cast<float>(json_real_value(value)));
+	return sp_ftoc(static_cast<float>(json_number_value(value)));
 }
 
 static cell_t GetObjectIntValue(IPluginContext *pContext, const cell_t *params)
@@ -537,7 +537,7 @@ static cell_t GetArrayFloatValue(IPluginContext *pContext, const cell_t *params)
 		return pContext->ThrowNativeError("Could not retrieve value at index %d", index);
 	}
 
-	return sp_ftoc(static_cast<float>(json_real_value(value)));
+	return sp_ftoc(static_cast<float>(json_number_value(value)));
 }
 
 static cell_t GetArrayIntValue(IPluginContext *pContext, const cell_t *params)


### PR DESCRIPTION
Fixes #45
Complies with standards by https://github.com/ErikMinekus/sm-ripext/pull/52#issuecomment-1070763089