### PR TITLE
Add SendImmediately option to HTTPRequest to send the request immediately instead of next tick

### DIFF
--- a/extension.h
+++ b/extension.h
@@ -175,6 +175,7 @@ public:
 #endif
 public:
 	void AddRequestToQueue(IHTTPContext *context);
+	void PerformRequest(IHTTPContext *context);
 
 	char caBundlePath[PLATFORM_MAX_PATH];
 };

--- a/http_natives.cpp
+++ b/http_natives.cpp
@@ -945,6 +945,30 @@ static cell_t SetRequestTimeout(IPluginContext *pContext, const cell_t *params)
 	return 1;
 }
 
+static cell_t GetRequestSendImmediately(IPluginContext *pContext, const cell_t *params)
+{
+	HTTPRequest *request = GetRequestFromHandle(pContext, params[1]);
+	if (request == NULL)
+	{
+		return 0;
+	}
+
+	return request->GetSendImmediately();
+}
+
+static cell_t SetRequestSendImmediately(IPluginContext *pContext, const cell_t *params)
+{
+	HTTPRequest *request = GetRequestFromHandle(pContext, params[1]);
+	if (request == NULL)
+	{
+		return 0;
+	}
+
+	request->SetSendImmediately(params[2]);
+
+	return 1;
+}
+
 static cell_t GetResponseData(IPluginContext *pContext, const cell_t *params)
 {
 	HandleError err;
@@ -1074,6 +1098,8 @@ const sp_nativeinfo_t http_natives[] =
 	{"HTTPRequest.MaxSendSpeed.set",	SetRequestMaxSendSpeed},
 	{"HTTPRequest.Timeout.get",			GetRequestTimeout},
 	{"HTTPRequest.Timeout.set",			SetRequestTimeout},
+	{"HTTPRequest.SendImmediately.get",	GetRequestSendImmediately},
+	{"HTTPRequest.SendImmediately.set",	SetRequestSendImmediately},
 	{"HTTPResponse.Data.get",			GetResponseData},
 	{"HTTPResponse.Status.get",			GetResponseStatus},
 	{"HTTPResponse.GetHeader",			GetResponseHeader},

--- a/httprequest.cpp
+++ b/httprequest.cpp
@@ -36,7 +36,14 @@ void HTTPRequest::Perform(const char *method, json_t *data, IChangeableForward *
 	HTTPRequestContext *context = new HTTPRequestContext(method, BuildURL(), data, BuildHeaders(), forward, value,
 		connectTimeout, maxRedirects, timeout, maxSendSpeed, maxRecvSpeed, useBasicAuth, username, password);
 
-	g_RipExt.AddRequestToQueue(context);
+	if (sendImmediately)
+	{
+		g_RipExt.PerformRequest(context);
+	}
+	else 
+	{
+		g_RipExt.AddRequestToQueue(context);
+	}
 }
 
 void HTTPRequest::DownloadFile(const char *path, IChangeableForward *forward, cell_t value)
@@ -47,7 +54,14 @@ void HTTPRequest::DownloadFile(const char *path, IChangeableForward *forward, ce
 	HTTPFileContext *context = new HTTPFileContext(false, BuildURL(), path, BuildHeaders(), forward, value,
 		connectTimeout, maxRedirects, timeout, maxSendSpeed, maxRecvSpeed, useBasicAuth, username, password);
 
-	g_RipExt.AddRequestToQueue(context);
+	if (sendImmediately)
+	{
+		g_RipExt.PerformRequest(context);
+	}
+	else 
+	{
+		g_RipExt.AddRequestToQueue(context);
+	}
 }
 
 void HTTPRequest::UploadFile(const char *path, IChangeableForward *forward, cell_t value)
@@ -58,7 +72,14 @@ void HTTPRequest::UploadFile(const char *path, IChangeableForward *forward, cell
 	HTTPFileContext *context = new HTTPFileContext(true, BuildURL(), path, BuildHeaders(), forward, value,
 		connectTimeout, maxRedirects, timeout, maxSendSpeed, maxRecvSpeed, useBasicAuth, username, password);
 
-	g_RipExt.AddRequestToQueue(context);
+	if (sendImmediately)
+	{
+		g_RipExt.PerformRequest(context);
+	}
+	else 
+	{
+		g_RipExt.AddRequestToQueue(context);
+	}
 }
 
 void HTTPRequest::PostForm(IChangeableForward *forward, cell_t value)
@@ -69,7 +90,14 @@ void HTTPRequest::PostForm(IChangeableForward *forward, cell_t value)
 	HTTPFormContext *context = new HTTPFormContext(BuildURL(), formData, BuildHeaders(), forward, value,
 		connectTimeout, maxRedirects, timeout, maxSendSpeed, maxRecvSpeed, useBasicAuth, username, password);
 
-	g_RipExt.AddRequestToQueue(context);
+	if (sendImmediately)
+	{
+		g_RipExt.PerformRequest(context);
+	}
+	else 
+	{
+		g_RipExt.AddRequestToQueue(context);
+	}
 }
 
 const std::string HTTPRequest::BuildURL() const
@@ -218,4 +246,14 @@ int HTTPRequest::GetTimeout() const
 void HTTPRequest::SetTimeout(int timeout)
 {
 	this->timeout = timeout;
+}
+
+bool HTTPRequest::GetSendImmediately() const
+{
+	return sendImmediately;
+}
+
+void HTTPRequest::SetSendImmediately(bool sendImmediately)
+{
+	this->sendImmediately = sendImmediately;
 }

--- a/httprequest.h
+++ b/httprequest.h
@@ -62,6 +62,9 @@ public:
 	int GetTimeout() const;
 	void SetTimeout(int timeout);
 
+	bool GetSendImmediately() const;
+	void SetSendImmediately(bool sendImmediately);
+
 private:
 	const std::string url;
 	std::string query;
@@ -75,6 +78,7 @@ private:
 	int maxRecvSpeed = 0;
 	int maxSendSpeed = 0;
 	int timeout = 30;
+	bool sendImmediately = false;
 };
 
 #endif // SM_RIPEXT_HTTPREQUEST_H_

--- a/pawn/scripting/include/ripext/http.inc
+++ b/pawn/scripting/include/ripext/http.inc
@@ -221,7 +221,7 @@ methodmap HTTPRequest < Handle
 	// Useful when sending the request before map change. Defaults to false.
 	property bool SendImmediately {
 		public native get();
-		public native set(bool Queued);
+		public native set(bool sendImmediately);
 	}
 }
 

--- a/pawn/scripting/include/ripext/http.inc
+++ b/pawn/scripting/include/ripext/http.inc
@@ -216,6 +216,13 @@ methodmap HTTPRequest < Handle
 		public native get();
 		public native set(int timeout);
 	}
+
+	// Send the request immediately, rather than waiting for the next game tick. 
+	// Useful when sending the request before map change. Defaults to false.
+	property bool SendImmediately {
+		public native get();
+		public native set(bool Queued);
+	}
 }
 
 methodmap HTTPResponse


### PR DESCRIPTION
Sometimes there is a need to send a request right before the server becomes unresponsive, like when changing the map. In this case, the usual behavior of waiting for the next tick won't do. So i made a kinda messy alternative option to HTTPRequest to send it immediately. 